### PR TITLE
Fix sieve's empty primes array

### DIFF
--- a/Algorithms/Math/Sieve of Eratorthenes.cpp
+++ b/Algorithms/Math/Sieve of Eratorthenes.cpp
@@ -11,7 +11,7 @@ using namespace std;
 // n -> max number that I will check
 // marked -> bool arr, that I mark composite nums
 // primes -> vector that contains primes from 2->n
-void sieve(long n, bool * marked, vector<int> primes){
+void sieve(long n, bool * marked, vector<int> &primes){
 
 	// O(n*sqrt(n)) - but much more faster in real time
 	for (long i = 2; i <= n; ++i){ 	


### PR DESCRIPTION
Hi @BedirT,
After reading your Sieve of Eratorthenes implementation, I found a problem in sieve function that it doesn't return anything. So my solution is to call by reference to primes array.
Please review this pull request.